### PR TITLE
Update WebSocket hostname and improve dispatcher handling

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -11,7 +11,7 @@ const App = () => {
   const dispatcher = useExplorerDispatcher();
   const setDispatcher = useSetAtom(dispatcherAtom);
   useEffect(() => {
-    setDispatcher(dispatcher);
+    setDispatcher(() => dispatcher);
   }, [dispatcher, setDispatcher]);
 
   return (

--- a/client/src/api/explorer.ts
+++ b/client/src/api/explorer.ts
@@ -48,7 +48,8 @@ const useExplorerDispatcher = () => {
 
   useEffect(() => {
     const ws = new WebSocket(serverWSHostName);
-    subscriberRef.current.addEventListener(explorerEvent, (event: Event) => {
+    const currentSubscriber = subscriberRef.current;
+    const subscriverHandler = (event: Event) => {
       // @ts-expect-error event is CustomEvent
       const message = event.detail as ExplorerMessage;
 
@@ -63,7 +64,8 @@ const useExplorerDispatcher = () => {
       };
 
       ws.send(JSON.stringify(explorationField));
-    });
+    };
+    currentSubscriber.addEventListener(explorerEvent, subscriverHandler);
     ws.onmessage = (event) => {
       if (event.type !== "text") {
         return;
@@ -202,6 +204,7 @@ const useExplorerDispatcher = () => {
     };
     return () => {
       ws.close();
+      currentSubscriber.removeEventListener(explorerEvent, subscriverHandler);
     };
   }, [
     setFieldMessages,

--- a/client/src/api/explorer.ts
+++ b/client/src/api/explorer.ts
@@ -2,7 +2,7 @@ import { useSetAtom } from "jotai";
 import { Position } from "../model/position";
 import { ExplorationField, ExplorationFieldEvents } from "../schema2/explore";
 import { serverWSHostName } from "./hostname";
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import fieldMessagesAtom from "../state/message";
 import fieldReactionsAtom from "../state/reactions";
 import { ReactionName } from "../model/reactions";
@@ -28,17 +28,23 @@ const useExplorerDispatcher = () => {
   const setFieldSpeakerPhones = useSetAtom(fieldSpeakerPhonesAtom);
   const setFieldExplorers = useSetAtom(fieldExplorersAtom);
 
-  const dispatcher: ExplorerMessageDispatcher = (mes) => {
+  const dispatcher: ExplorerMessageDispatcher = useCallback((mes) => {
     if (!mes) return;
     subscriberRef.current.dispatchEvent(
       new CustomEvent(explorerEvent, {
         detail: {
-          position: mes.position,
-          size: mes.size,
+          position: {
+            x: Math.round(mes.position.x),
+            y: Math.round(mes.position.y),
+          },
+          size: {
+            width: Math.round(mes.size.width),
+            height: Math.round(mes.size.height),
+          },
         },
       }),
     );
-  };
+  }, []);
 
   useEffect(() => {
     const ws = new WebSocket(serverWSHostName);

--- a/client/src/api/hostname.ts
+++ b/client/src/api/hostname.ts
@@ -1,3 +1,3 @@
 const serverHostName = "http://localhost:8000";
-export const serverWSHostName = "ws://localhost:8000";
+export const serverWSHostName = "ws://localhost:8000/ws";
 export default serverHostName;

--- a/client/src/pixi/Canvas.tsx
+++ b/client/src/pixi/Canvas.tsx
@@ -14,7 +14,8 @@ import {
 } from "../model/position";
 import Explorer from "./components/Explorer";
 import PIXI from "pixi.js";
-import useExplorerDispatcher from "../api/explorer";
+import { useAtomValue } from "jotai";
+import dispatcherAtom from "../state/dispatcher";
 
 const mountHandler = import.meta.env.DEV
   ? (app: PIXI.Application) => {
@@ -41,7 +42,7 @@ const Canvas: React.FC<Props> = (props) => {
   } | null>(null);
   const [intervalID, setIntervalID] = useState<number | null>(null);
   const stageRef = useRef<HTMLDivElement>(null);
-  const dispatcher = useExplorerDispatcher();
+  const dispatcher = useAtomValue(dispatcherAtom);
 
   useEffect(() => {
     const width = (window.innerWidth * 3) / 5;
@@ -79,24 +80,28 @@ const Canvas: React.FC<Props> = (props) => {
           y: targetPosition.y - position.y,
         };
         if (Math.abs(diff.x) < 3 && Math.abs(diff.y) < 3) {
-          dispatcher({
+          dispatcher?.({
             position: targetPosition,
             size: fieldSize,
           });
+          console.log("stop !", targetPosition);
+
+          clearInterval(intervalID ?? undefined);
           return targetPosition;
         }
         const nextPosition = calcNewPosition(position, {
           x: diff.x / 10,
           y: diff.y / 10,
         });
-        dispatcher({
+        dispatcher?.({
           position: nextPosition,
           size: fieldSize,
         });
+        console.log("moving...", nextPosition);
         return nextPosition;
       });
     },
-    [dispatcher, fieldSize],
+    [dispatcher, fieldSize, intervalID],
   );
 
   const onFieldClick = useCallback(
@@ -124,15 +129,18 @@ const Canvas: React.FC<Props> = (props) => {
         userDisplayPosition,
       );
 
-      if (intervalID !== null) {
-        clearInterval(intervalID);
-      }
       const id = setInterval(() => {
         updateUserPosition(clickPosition);
       }, 1000 / 60);
-      setIntervalID(id);
+      console.log("start !", clickPosition);
+      setIntervalID((old) => {
+        if (old !== null) {
+          clearInterval(old);
+        }
+        return id;
+      });
     },
-    [intervalID, updateUserPosition, userDisplayPosition, userPosition],
+    [updateUserPosition, userDisplayPosition, userPosition],
   );
 
   if (

--- a/client/src/pixi/Canvas.tsx
+++ b/client/src/pixi/Canvas.tsx
@@ -40,7 +40,7 @@ const Canvas: React.FC<Props> = (props) => {
     width: number;
     height: number;
   } | null>(null);
-  const [intervalID, setIntervalID] = useState<number | null>(null);
+  const intervalID = useRef<number | null>(null);
   const stageRef = useRef<HTMLDivElement>(null);
   const dispatcher = useAtomValue(dispatcherAtom);
 
@@ -84,9 +84,8 @@ const Canvas: React.FC<Props> = (props) => {
             position: targetPosition,
             size: fieldSize,
           });
-          console.log("stop !", targetPosition);
 
-          clearInterval(intervalID ?? undefined);
+          clearInterval(intervalID.current ?? undefined);
           return targetPosition;
         }
         const nextPosition = calcNewPosition(position, {
@@ -97,7 +96,6 @@ const Canvas: React.FC<Props> = (props) => {
           position: nextPosition,
           size: fieldSize,
         });
-        console.log("moving...", nextPosition);
         return nextPosition;
       });
     },
@@ -129,16 +127,14 @@ const Canvas: React.FC<Props> = (props) => {
         userDisplayPosition,
       );
 
+      if (intervalID.current !== null) {
+        clearInterval(intervalID.current);
+      }
+
       const id = setInterval(() => {
         updateUserPosition(clickPosition);
       }, 1000 / 60);
-      console.log("start !", clickPosition);
-      setIntervalID((old) => {
-        if (old !== null) {
-          clearInterval(old);
-        }
-        return id;
-      });
+      intervalID.current = id;
     },
     [updateUserPosition, userDisplayPosition, userPosition],
   );


### PR DESCRIPTION
Change the WebSocket hostname to include the `/ws` suffix, prevent sending float values, and ensure the dispatcher is sourced correctly. Additionally, fix an issue where the interval was continuously called and perform necessary cleanup.