### PR TITLE
🐛 他の探索者が見えるように

### DIFF
--- a/client/src/api/explorer.ts
+++ b/client/src/api/explorer.ts
@@ -164,11 +164,12 @@ const useExplorerDispatcher = () => {
         // NOTE: バックエンドは proto に従ってない
         const explorerActions =
           events.explorerActions as unknown as ExplorerAction[];
+        const newExplorers = new Map(explorers);
         explorerActions.forEach((action) => {
           switch (action.type) {
             case "arrive": {
               const explorer = action;
-              explorers.set(explorer.id ?? "", {
+              newExplorers.set(explorer.id ?? "", {
                 id: explorer.id ?? "",
                 position: {
                   x: explorer.position?.x ?? 0,
@@ -179,14 +180,14 @@ const useExplorerDispatcher = () => {
               break;
             }
             case "leave": {
-              explorers.delete(action.id);
+              newExplorers.delete(action.id);
               break;
             }
             case "move": {
               const explorer = action;
-              const prevExplorer = explorers.get(explorer.id ?? "");
+              const prevExplorer = newExplorers.get(explorer.id ?? "");
               if (!prevExplorer) return;
-              explorers.set(explorer.id ?? "", {
+              newExplorers.set(explorer.id ?? "", {
                 id: explorer.id ?? "",
                 position: {
                   x: explorer.position?.x ?? 0,
@@ -203,7 +204,7 @@ const useExplorerDispatcher = () => {
           }
           if (action.type === "arrive") {
             const explorer = action;
-            explorers.set(explorer.id ?? "", {
+            newExplorers.set(explorer.id ?? "", {
               id: explorer.id ?? "",
               position: {
                 x: explorer.position?.x ?? 0,
@@ -213,7 +214,7 @@ const useExplorerDispatcher = () => {
             });
           }
         });
-        return explorers;
+        return newExplorers;
       });
     };
     return () => {

--- a/client/src/pixi/World.tsx
+++ b/client/src/pixi/World.tsx
@@ -96,7 +96,7 @@ const World: React.FC<Props> = ({
     return Array.from(explorers.values()).map((explorer) => {
       return (
         <OtherExplorer
-          key={explorer.userId}
+          key={explorer.id}
           explorer={explorer}
           previousPosition={explorer.previousPosition}
         />

--- a/client/src/pixi/components/OtherExplorer.tsx
+++ b/client/src/pixi/components/OtherExplorer.tsx
@@ -1,7 +1,7 @@
 import { Position } from "../../model/position";
 import ExplorerModel from "../../model/explorer";
 import Explorer from "./Explorer";
-import { useUser } from "../../api/user";
+import { useMe, useUser } from "../../api/user";
 import { traqIconURL } from "../../util/icon";
 import { useTick } from "@pixi/react";
 import { useState } from "react";
@@ -16,6 +16,7 @@ const OtherExplorer: React.FC<Props> = ({ explorer, previousPosition }) => {
   const { position: targetPosition, userId } = explorer; // 目標の位置
   const { data, error, isLoading } = useUser(userId);
   const [position, setPosition] = useState(targetPosition); // 実際の現在の位置
+  const { data: me } = useMe();
 
   useTick(() => {
     if (previousPosition) {
@@ -44,6 +45,9 @@ const OtherExplorer: React.FC<Props> = ({ explorer, previousPosition }) => {
   }
   const user = data.user;
   if (!user) {
+    return null;
+  }
+  if (me?.user?.id === user.id) {
     return null;
   }
 


### PR DESCRIPTION
This pull request includes several changes to the explorer dispatcher logic and the `OtherExplorer` component to improve state management and user filtering.

### Improvements to explorer dispatcher logic:

* [`client/src/api/explorer.ts`](diffhunk://#diff-5d8bc3beb41abdd3b4b2ad6101c40134290a1f4d3dd5c9903a354bcb17033a51R167-R172): Replaced the `explorers` map with a new `newExplorers` map to ensure immutability when updating the explorers' state. [[1]](diffhunk://#diff-5d8bc3beb41abdd3b4b2ad6101c40134290a1f4d3dd5c9903a354bcb17033a51R167-R172) [[2]](diffhunk://#diff-5d8bc3beb41abdd3b4b2ad6101c40134290a1f4d3dd5c9903a354bcb17033a51L182-R190) [[3]](diffhunk://#diff-5d8bc3beb41abdd3b4b2ad6101c40134290a1f4d3dd5c9903a354bcb17033a51L206-R207) [[4]](diffhunk://#diff-5d8bc3beb41abdd3b4b2ad6101c40134290a1f4d3dd5c9903a354bcb17033a51L216-R217)

### Enhancements to `OtherExplorer` component:

* [`client/src/pixi/World.tsx`](diffhunk://#diff-313afcb77989a7a696d278c16a804971014ad06aae6cc7f3eb0399e7dd1fbdd6L99-R99): Updated the key for the `OtherExplorer` component from `explorer.userId` to `explorer.id` to ensure unique keys.
* [`client/src/pixi/components/OtherExplorer.tsx`](diffhunk://#diff-b625578246adbd53ffec4004c2c6c001b089df8f8c8f4d9d77f7439b5a00fd77L4-R4): Added the `useMe` hook to fetch the current user's data and filter out the current user's explorer from being rendered. [[1]](diffhunk://#diff-b625578246adbd53ffec4004c2c6c001b089df8f8c8f4d9d77f7439b5a00fd77L4-R4) [[2]](diffhunk://#diff-b625578246adbd53ffec4004c2c6c001b089df8f8c8f4d9d77f7439b5a00fd77R19) [[3]](diffhunk://#diff-b625578246adbd53ffec4004c2c6c001b089df8f8c8f4d9d77f7439b5a00fd77R50-R52)